### PR TITLE
fix: correct typo in header GitHub link

### DIFF
--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -107,7 +107,7 @@ watch(selectedFramework, () => {
           <UNavigationMenu :items="menu.slice(3)" :ui="{ viewport: 'min-w-[500px] -left-full' }" class="justify-center" />
         </div>
         <UButton
-          to="https://github.com/unhead/unjs" target="_blank" class="text-black
+          to="https://github.com/unjs/unhead" target="_blank" class="text-black
         hidden sm:flex items-center justify-center items-center bg-gradient bg-gradient-to-r from-[#FBBF24] to-[#f0db4f]"
           size="sm"
         >


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Just fixing a typo on the main GitHub button of the header:
```diff
- https://github.com/unhead/unjs
+ https://github.com/unjs/unhead
```