### PR TITLE
fix: ads fallback not showing

### DIFF
--- a/app/components/ads/Ads.vue
+++ b/app/components/ads/Ads.vue
@@ -19,7 +19,9 @@ function attachRouteWatcher() {
         placement="unheadunjsio"
         trigger="onNuxtReady"
       >
-        <AdsFallback />
+        <template #error>
+          <AdsFallback />
+        </template>
       </ScriptCarbonAds>
     </ClientOnly>
   </div>

--- a/app/components/ads/AdsFallback.vue
+++ b/app/components/ads/AdsFallback.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="py-2 px-4 rounded-md bg-neutral-100 dark:bg-white dark:bg-opacity-10 flex flex-col md:flex-row w-full items-center mt-4">
+  <div class="py-2 px-4 rounded-md bg-neutral-100 dark:bg-white/5 dark:bg-opacity-10 flex flex-col md:flex-row w-full items-center mt-4">
     <div>
-      <p class="pt-2 m-0 font-bold sm:text-sm text-(--ui-text-highlighted)">
+      <p class="py-2 m-0 font-bold sm:text-sm text-(--ui-text-highlighted)">
         Unhead needs you!
       </p>
       <p class="pb-2 m-0 leading-normal text-neutral-600 dark:text-white sm:text-xs">


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I'm using your documentation websites as reference to implement Carbon ads 😛 Noticed the fallback component is not showing, this should fix that.

FYI - the fallback is also broken on unlighthouse.dev but shows an empty container div instead.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
